### PR TITLE
:bug: board paging warning error 처리

### DIFF
--- a/src/main/java/com/tbfp/teamplannerbe/domain/board/dto/BoardSearchCondition.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/board/dto/BoardSearchCondition.java
@@ -10,4 +10,5 @@ import lombok.*;
 public class BoardSearchCondition {
 
     private String category;
+    private String activityField;
 }

--- a/src/main/java/com/tbfp/teamplannerbe/domain/board/repository/impl/BoardQuerydslRepositoryImpl.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/board/repository/impl/BoardQuerydslRepositoryImpl.java
@@ -37,14 +37,16 @@ public class BoardQuerydslRepositoryImpl extends Querydsl4RepositorySupport impl
     @Override
     public Page<Board> getBoardList(BoardSearchCondition condition, Pageable pageable) {
 
+        String[] word = (condition.getActivityField()!=null) ? condition.getActivityField().split("/") : null;
+
+        BooleanExpression activityFieldExpression = (word != null) ? activityFieldContains(word) : null;
+
 
         StringExpression recruitmentPeriodEndDate = Expressions.stringTemplate("STR_TO_DATE(SUBSTRING_INDEX({0}, '~', -1), '%Y.%m.%d')", board.recruitmentPeriod);
         BooleanExpression recruitmentPeriodPredicate = recruitmentPeriodEndDate.goe(String.valueOf(LocalDate.now()));
 
         JPAQuery<Board> contentQuery = selectFrom(board)
-                .leftJoin(board.comments, comment).fetchJoin()
-                .where(categoryEq(condition.getCategory()))
-                .where(recruitmentPeriodPredicate)
+                .where(categoryEq(condition.getCategory()),recruitmentPeriodPredicate,activityFieldExpression)
                 .orderBy(getOrderSpecifier(pageable.getSort()).stream().toArray(OrderSpecifier[]::new))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
@@ -53,12 +55,12 @@ public class BoardQuerydslRepositoryImpl extends Querydsl4RepositorySupport impl
 
         JPAQuery<Long> countQuery = select(board.count())
                 .from(board)
-                .where(categoryEq(condition.getCategory()))
-                .where(recruitmentPeriodPredicate);
+                .where(categoryEq(condition.getCategory()),recruitmentPeriodPredicate,activityFieldExpression);
 
         long totalCount = countQuery.fetchOne();
         return new PageImpl<>(content, pageable, totalCount);
     }
+
 
     @Override
     public List<Board> getBoardAndComment(Long boardId) {
@@ -97,6 +99,19 @@ public class BoardQuerydslRepositoryImpl extends Querydsl4RepositorySupport impl
     private BooleanExpression categoryEq(String category) {
         return hasText(category) ? board.category.eq(category) : null;
     }
+    private BooleanExpression activityFieldContains(String[] activityFields) {
+        BooleanExpression result = null;
+        for (String field : activityFields) {
+            if (hasText(field)) {
+                BooleanExpression fieldExpression = board.activityField.like("%" + field + "%");
+                // or 을 처리하여 split 한 word 가 포함되어 있는지 확인해서 넣어줌
+                // 예 문학/시나리오  (board.activityField.like("%문학%").or(board.activityField.like("%시나리오%")))
+                result = (result == null) ? fieldExpression : result.or(fieldExpression);
+            }
+        }
+        return result;
+    }
+
     private BooleanExpression boardIdEq(Long boardId) {
         return hasText(String.valueOf(boardId)) ? board.id.eq(boardId) : null;
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,6 +15,7 @@ spring:
         show_sql: true
         format_sql: true
         use_sql_comments: true
+        default_batch_fetch_size: 100
   mail:
     host: smtp.gmail.com
     port: 587
@@ -68,10 +69,10 @@ spring:
     user: root
     password:
 
-logging.level:
-
-  org.hibernate.SQL: debug
-  org.hibernate.type: trace
+#logging.level:
+#
+#  org.hibernate.SQL: debug
+#  org.hibernate.type: trace
 
 jwt:
   secret_key: ENC(mmf+mUwEemm7lqzn7MyjYaYVlRpGN25Xpvmo4jQ4ctx7tNdCrjBXR2JdWIZjh6LAupCdrOSI44WtK+dUp4tym1fIiEfdYbNpNudokWdOtKf1JnRMMB8PasGfLDAPofA0uNViAU3SZeK0hd9oeTBo3P+LawaOOimGe4G7FZqQIA0x4B0IIkJx9WGN+O3zam1UZdtcTd4WA0Ojnal1JcjcwDRJ1XcmsDyGHVQ5LSWMN0PydTg0hCd4COYUz5ORRKAE2ytwgmhPF0A=)


### PR DESCRIPTION
## 개요

## 문제점
컬렉션을 페치 조인하면 일대다 조인이 발생하므로 데이터가 예측할 수 없이 증가한다. (row 수 증가)
일다대에서 일(board 1)을 기준으로 페이징을 하는 것이 목적이다. 그런데 데이터는 다(Comment N)를 기준으로 row가 생성된다.
Board를 기준으로 페이징 하고 싶은데, 다(N) Comment기준이 되어버린다.

## 해결내용

- [x]  toOne 관계를 fetch join 함. toOne 관계는 fetch join을 해도 row는 증가하지않으므로 페이징 하는데 문제가 되지않음
- [x]  oneToMany에 관련된 컬렉션 조회는 batch fetch size 를 설정해서 where 에 in 절로 size 만큼처리
- [x]  활동분야 별 "/" 별로 split 짤라 OrderSpecifier를 사용하여 동적쿼리 작성

