### PR TITLE
:sparkles: notification readcount update

### DIFF
--- a/src/main/java/com/tbfp/teamplannerbe/domain/notification/domain/Notification.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/notification/domain/Notification.java
@@ -24,6 +24,7 @@ public class Notification{
     private String recruitmentProfileImage;
 
     @DynamoDBAttribute
+
     private String content;
     @DynamoDBAttribute
     private Long memberId;
@@ -31,4 +32,13 @@ public class Notification{
     @DynamoDBAttribute
     @DynamoDBTypeConverted(converter = DynamoDBConfig.LocalDateTimeConverter.class)
     private LocalDateTime createdAt;
+
+    @DynamoDBAttribute
+    private Integer readCount;
+
+    public void updateNotificationReadCount(Integer readCount) {
+        if(readCount>0){
+            this.readCount=readCount-1;
+        }
+    }
 }

--- a/src/main/java/com/tbfp/teamplannerbe/domain/notification/dto/request/CreateMessageEvent.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/notification/dto/request/CreateMessageEvent.java
@@ -16,6 +16,7 @@ public class CreateMessageEvent {
     private Long memberId;
     private String recruitmentProfileImage;
     private LocalDateTime createdDate;
+    private Integer readCount;
 
 
     public static Notification toEntity(CreateMessageEvent createMessageEvent) {
@@ -24,6 +25,7 @@ public class CreateMessageEvent {
                 .content(createMessageEvent.getContent())
                 .createdAt(LocalDateTime.now())
                 .recruitmentProfileImage(createMessageEvent.recruitmentProfileImage)
+                .readCount(1)
                 .build();
     }
 }

--- a/src/main/java/com/tbfp/teamplannerbe/domain/notification/dto/response/NotificationListResponseDto.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/notification/dto/response/NotificationListResponseDto.java
@@ -14,6 +14,7 @@ public class NotificationListResponseDto {
     private Long memberId;
     private String recruitmentProfileImage;
     private LocalDateTime createdDate;
+    private Integer readCount;
 
     public static NotificationListResponseDto from(Notification notification) {
         return NotificationListResponseDto.builder()
@@ -21,6 +22,7 @@ public class NotificationListResponseDto {
                 .recruitmentProfileImage(notification.getRecruitmentProfileImage())
                 .createdDate(notification.getCreatedAt())
                 .memberId(notification.getMemberId())
+                .readCount(notification.getReadCount())
                 .build();
 
     }

--- a/src/main/java/com/tbfp/teamplannerbe/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/notification/dto/response/NotificationResponseDto.java
@@ -18,6 +18,7 @@ public class NotificationResponseDto {
     private String content;
     private LocalDateTime createdAt;
     private String recruitmentProfileImage;
+    private Integer readCount;
 
     public static NotificationResponseDto from(Notification notification) {
 
@@ -26,6 +27,7 @@ public class NotificationResponseDto {
                 .id(notification.getId())
                 .createdAt(notification.getCreatedAt())
                 .recruitmentProfileImage(notification.getRecruitmentProfileImage())
+                .readCount(notification.getReadCount())
                 .build();
     }
 }

--- a/src/main/java/com/tbfp/teamplannerbe/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/notification/repository/NotificationRepository.java
@@ -7,5 +7,7 @@ import java.util.List;
 
 public interface NotificationRepository {
     void save(Notification notification);
+    void saveAll(List<Notification> notificationList);
+
     List<Notification> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/tbfp/teamplannerbe/domain/notification/repository/impl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/notification/repository/impl/NotificationRepositoryImpl.java
@@ -24,6 +24,11 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     }
 
     @Override
+    public void saveAll(List<Notification> notificationList) {
+        dynamoNotificationRepository.saveAll(notificationList);
+    }
+
+    @Override
     public List<Notification> findAllByMemberId(Long memberId) {
 
         List<Notification> notificationList = dynamoNotificationRepository.findAllByMemberId(memberId);


### PR DESCRIPTION
## 개요

- 모집공고를 올린 공고작성자에게 참여신청이 왔을경우 실시간으로 알림을 줌.
- SSE프로토콜을 사용하여 한번 커넥션을 맺고 구독을 한 유저에게 바로 데이터를 전달함

## 작업 사항

- [x] redis pub/sub 을 이용하여 구독한 유저에게 바로 데이터를 전달한다.
- [x] readCount를 설정시켜 해당 데이터를 읽었을 시 count를 0으로 초기화시킴

## PR 타입
- 기능 개발