### PR TITLE
:sparkles: 프로필 추천 구현

### DIFF
--- a/src/main/java/com/tbfp/teamplannerbe/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/member/dto/MemberDto.java
@@ -1,0 +1,94 @@
+package com.tbfp.teamplannerbe.domain.member.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.tbfp.teamplannerbe.domain.member.Education;
+import com.tbfp.teamplannerbe.domain.member.Job;
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+
+public class MemberDto {
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ProfileInfoForScoringDto {
+        //memberid
+        private Long id;
+        //basicprofile
+        @Enumerated(EnumType.STRING)
+        private Job job;
+
+        @Enumerated(EnumType.STRING)
+        private Education education;
+
+        private LocalDate admissionDate;
+
+        private LocalDate birth;
+
+        private String address;
+
+        //techStack
+        //map : techStackItem.id, skillLevel
+        private List<TechStackItemDto> techStackItems;
+
+        //activity
+        //이름비슷한정도 -> 갯수
+        private List<String> activitySubjects;
+
+        //certification
+        //이름비슷한정도 -> 갯수
+        private List<String> certificationNames;
+
+        //evaluation
+        private Double averageStat;
+
+        @QueryProjection
+        public ProfileInfoForScoringDto(Long id, Job job, Education education, LocalDate admissionDate, LocalDate birth, String address, List<TechStackItemDto> techStackItems, List<String> activitySubjects, List<String> certificationNames, Double averageStat){
+            this.id = id;
+            this.job = job;
+            this.education = education;
+            this.admissionDate = admissionDate;
+            this.birth = birth;
+            this.address = address;
+            this.techStackItems = techStackItems;
+            this.activitySubjects = activitySubjects;
+            this.certificationNames = certificationNames;
+            this.averageStat = averageStat;
+        }
+        @Getter
+        @Builder
+        @NoArgsConstructor(access = AccessLevel.PROTECTED)
+        public static class TechStackItemDto {
+            private Long id;
+            private String name;
+            private Integer skillLevel;
+
+            @QueryProjection
+            public TechStackItemDto(Long id, String name, Integer skillLevel){
+                this.id = id;
+                this.name = name;
+                this.skillLevel = skillLevel;
+            }
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ScoreAndSimilaritiesDto{
+        private Long id;
+        private Double score;
+        private List<String> similarities;
+
+        @QueryProjection
+        public ScoreAndSimilaritiesDto(Long id, Double score, List<String> similarities){
+            this.id = id;
+            this.score = score;
+            this.similarities = similarities;
+        }
+    }
+}
+

--- a/src/main/java/com/tbfp/teamplannerbe/domain/member/repository/MemberQuerydslRepository.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/member/repository/MemberQuerydslRepository.java
@@ -1,7 +1,9 @@
 package com.tbfp.teamplannerbe.domain.member.repository;
 
 import com.tbfp.teamplannerbe.domain.auth.ProviderType;
+import com.tbfp.teamplannerbe.domain.member.dto.MemberDto;
 import com.tbfp.teamplannerbe.domain.member.entity.Member;
+import com.tbfp.teamplannerbe.domain.profile.dto.ProfileResponseDto;
 import com.tbfp.teamplannerbe.domain.recruitment.entity.Recruitment;
 
 import java.util.List;
@@ -27,4 +29,7 @@ public interface MemberQuerydslRepository {
 
     List<Recruitment> getApplicantList(String username);
 
+    List<MemberDto.ProfileInfoForScoringDto> findAllProfileInfosForScoring();
+
+    ProfileResponseDto.RecommendedUserResponseDto getRecommendedUserResponseDto(Long id, List<String> similarities);
 }

--- a/src/main/java/com/tbfp/teamplannerbe/domain/profile/dto/ProfileResponseDto.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/profile/dto/ProfileResponseDto.java
@@ -4,14 +4,11 @@ import com.tbfp.teamplannerbe.domain.member.Education;
 import com.tbfp.teamplannerbe.domain.member.Gender;
 import com.tbfp.teamplannerbe.domain.member.Job;
 import com.tbfp.teamplannerbe.domain.member.entity.Member;
-import com.tbfp.teamplannerbe.domain.profile.CRUDType;
-import com.tbfp.teamplannerbe.domain.profile.SkillLevel;
 import com.tbfp.teamplannerbe.domain.profile.entity.*;
 import lombok.*;
 
 import javax.validation.constraints.Pattern;
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.List;
 
 public class ProfileResponseDto {
@@ -133,7 +130,17 @@ public class ProfileResponseDto {
         private Integer stat4;
         private Integer stat5;
     }
-
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class RecommendedUserResponseDto {
+        private Long id;
+        private String nickname;
+        private String profileIntro;
+        private String profileImage;
+        private List<String> similarities;
+    }
 
     @Getter
     @Builder
@@ -145,6 +152,7 @@ public class ProfileResponseDto {
         private List<ActivityResponseDto> activities;
         private List<CertificationResponseDto> certifications;
         private List<EvaluationResponseDto> evaluations;
+        private List<RecommendedUserResponseDto> recommendedUsers;
     }
 
     @Getter

--- a/src/main/java/com/tbfp/teamplannerbe/domain/profile/entity/TechStack.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/profile/entity/TechStack.java
@@ -24,11 +24,11 @@ public class TechStack extends BaseTimeEntity{
 
     private Integer skillLevel;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "TECH_STACK_ITEM_ID")
     private TechStackItem techStackItem;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 

--- a/src/main/java/com/tbfp/teamplannerbe/domain/profile/repository/TechStackQuerydslRepository.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/profile/repository/TechStackQuerydslRepository.java
@@ -1,0 +1,10 @@
+package com.tbfp.teamplannerbe.domain.profile.repository;
+
+import com.tbfp.teamplannerbe.domain.profile.entity.TechStack;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TechStackQuerydslRepository {
+    Optional<List<TechStack>> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/tbfp/teamplannerbe/domain/profile/repository/TechStackRepository.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/profile/repository/TechStackRepository.java
@@ -7,8 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface TechStackRepository extends JpaRepository<TechStack,Long> {
-    Optional<List<TechStack>> findAllByMemberId(Long memberId);
+public interface TechStackRepository extends JpaRepository<TechStack,Long>, TechStackQuerydslRepository {
 
     void deleteAllByIdInAndMember(List<Long> techStackIds, Member member);
 

--- a/src/main/java/com/tbfp/teamplannerbe/domain/profile/repository/impl/TechStackQuerydslRepositoryImpl.java
+++ b/src/main/java/com/tbfp/teamplannerbe/domain/profile/repository/impl/TechStackQuerydslRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.tbfp.teamplannerbe.domain.profile.repository.impl;
+
+import com.tbfp.teamplannerbe.domain.common.querydsl.support.Querydsl4RepositorySupport;
+import com.tbfp.teamplannerbe.domain.profile.entity.TechStack;
+import com.tbfp.teamplannerbe.domain.profile.repository.TechStackQuerydslRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.tbfp.teamplannerbe.domain.profile.entity.QTechStack.techStack;
+import static com.tbfp.teamplannerbe.domain.profile.entity.QTechStackItem.techStackItem;
+
+public class TechStackQuerydslRepositoryImpl extends Querydsl4RepositorySupport implements TechStackQuerydslRepository {
+    public TechStackQuerydslRepositoryImpl() {
+        super(TechStack.class);
+    }
+
+    public Optional<List<TechStack>> findAllByMemberId(Long memberId){
+        return Optional.ofNullable(selectFrom(techStack)
+                .where(techStack.member.id.eq(memberId))
+                .leftJoin(techStack.techStackItem, techStackItem).fetchJoin()
+                .fetch());
+    }
+}

--- a/src/test/java/com/tbfp/teamplannerbe/domain/profile/service/impl/ProfileServiceImplTest.java
+++ b/src/test/java/com/tbfp/teamplannerbe/domain/profile/service/impl/ProfileServiceImplTest.java
@@ -1,0 +1,39 @@
+package com.tbfp.teamplannerbe.domain.profile.service.impl;
+
+import com.tbfp.teamplannerbe.domain.profile.service.ProfileService;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ProfileServiceImplTest {
+
+    @Autowired
+    ProfileService profileService;
+
+    @Autowired
+    ProfileServiceImpl profileServiceImpl;
+
+    static Stream<Arguments> addressPairs() {
+        return Stream.of(
+                Arguments.of("경기도 삼일시 이사구 오팔동", "삼일시 이사구",0.46667),
+                Arguments.of("삼일시 이사구", "삼일 이사",0.71429),
+                Arguments.of("서울특별시 강남구 역삼동", "서울시 역삼동",0.53846),
+                Arguments.of("서울시 강남구 역삼동","서울시 강남구 역삼",0.90909)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("addressPairs")
+    void getMatchWordCount_Test(String addressStr1, String addressStr2, Double matchWordCountAnswer){
+        double matchWordCount = profileServiceImpl.getMatchWordCount(addressStr1,addressStr2);
+        double epsilon = 1e-4;
+        assertEquals(matchWordCount,matchWordCountAnswer,epsilon);
+    }
+}


### PR DESCRIPTION
## 개요

- 현재 페이지에서 조회하고 있는 사용자와 비슷한 다른 사용자들의 프로필 추천 기능을 개발한다.
- 기본정보, 기술스택, 활동, 자격증, 평가점수 등을 종합하여 점수를 매겨 상위 5명에 대해 추천한다.
- 서브쿼리로 조회하는 정보들이 오류가 있어 확인 필요

## 작업 사항

- [x] 프로필 추천 구현

## PR 타입
- 기능 개발